### PR TITLE
feat:Added list_dirplus function and treeplus example

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-ko_fi: veeso

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,9 +15,7 @@ jobs:
         run: brew update && brew install samba pkg-config && brew link --force samba
       - name: Build
         run: cargo build --all-targets
-      - name: Run tests
-        run: cargo test --verbose --no-default-features --no-fail-fast
-        env:
-          RUST_LOG: trace
+      - name: Format
+        run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy -- -Dwarnings

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: brew update && brew install samba
+        run: brew update && brew install samba pkg-config && brew link --force samba
       - name: Build
         run: cargo build --all-targets
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+
+target-install/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,17 +23,17 @@ name = "pavao"
 path = "src/lib.rs"
 
 [dependencies]
-lazy_static = "^1.4.0"
+lazy_static = "^1.4"
 libc = "^0.2.121"
-log = "^0.4.14"
-thiserror = "^1.0.0"
+log = "^0.4"
+thiserror = "^1.0"
 
 [dev-dependencies]
 argh = "0.1.7"
-env_logger = "^0.9.0"
+env_logger = "^0.10"
 pretty_assertions = "^1.0.0"
-rpassword = "5.0.1"
-serial_test = "^0.6.0"
+rpassword = "7.2"
+serial_test = "^2"
 
 [build-dependencies]
 pkg-config = "0.3.25"
@@ -49,3 +49,7 @@ path = "examples/transfer.rs"
 [[example]]
 name = "tree"
 path = "examples/tree.rs"
+
+[[example]]
+name = "treeplus"
+path = "examples/treeplus.rs"

--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -1,9 +1,9 @@
-use argh::FromArgs;
-
-use pavao::{SmbClient, SmbCredentials, SmbOpenOptions, SmbOptions};
 use std::fs::File;
 use std::io;
 use std::path::Path;
+
+use argh::FromArgs;
+use pavao::{SmbClient, SmbCredentials, SmbOpenOptions, SmbOptions};
 
 #[derive(FromArgs)]
 #[argh(description = "

--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -60,5 +60,5 @@ fn main() {
 
 /// Read a secret from tty with customisable prompt
 fn read_secret_from_tty(prompt: &str) -> std::io::Result<String> {
-    rpassword::read_password_from_tty(Some(prompt))
+    rpassword::prompt_password(prompt)
 }

--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -1,5 +1,5 @@
 use argh::FromArgs;
-use env_logger;
+
 use pavao::{SmbClient, SmbCredentials, SmbOpenOptions, SmbOptions};
 use std::fs::File;
 use std::io;
@@ -60,8 +60,5 @@ fn main() {
 
 /// Read a secret from tty with customisable prompt
 fn read_secret_from_tty(prompt: &str) -> std::io::Result<String> {
-    match rpassword::read_password_from_tty(Some(prompt)) {
-        Ok(p) => Ok(p),
-        Err(err) => Err(err),
-    }
+    rpassword::read_password_from_tty(Some(prompt))
 }

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -1,5 +1,5 @@
 use argh::FromArgs;
-use env_logger;
+
 use pavao::{SmbClient, SmbCredentials, SmbDirent, SmbDirentType, SmbOptions, SmbStat};
 use std::path::PathBuf;
 
@@ -45,10 +45,7 @@ fn main() {
 
 /// Read a secret from tty with customisable prompt
 fn read_secret_from_tty(prompt: &str) -> std::io::Result<String> {
-    match rpassword::read_password_from_tty(Some(prompt)) {
-        Ok(p) => Ok(p),
-        Err(err) => Err(err),
-    }
+    rpassword::read_password_from_tty(Some(prompt))
 }
 
 fn tree(client: &SmbClient, uri: &str, depth: usize) {

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -1,7 +1,7 @@
-use argh::FromArgs;
-
-use pavao::{SmbClient, SmbCredentials, SmbDirent, SmbDirentType, SmbOptions, SmbStat};
 use std::path::PathBuf;
+
+use argh::FromArgs;
+use pavao::{SmbClient, SmbCredentials, SmbDirent, SmbDirentType, SmbOptions, SmbStat};
 
 #[derive(FromArgs)]
 #[argh(description = "

--- a/examples/tree.rs
+++ b/examples/tree.rs
@@ -45,7 +45,7 @@ fn main() {
 
 /// Read a secret from tty with customisable prompt
 fn read_secret_from_tty(prompt: &str) -> std::io::Result<String> {
-    rpassword::read_password_from_tty(Some(prompt))
+    rpassword::prompt_password(prompt)
 }
 
 fn tree(client: &SmbClient, uri: &str, depth: usize) {

--- a/examples/treeplus.rs
+++ b/examples/treeplus.rs
@@ -1,8 +1,6 @@
 use argh::FromArgs;
 use env_logger;
-use pavao::{
-    SmbClient, SmbCredentials, SmbDirent, SmbDirentInfo, SmbDirentType, SmbOptions, SmbStat,
-};
+use pavao::{SmbClient, SmbCredentials, SmbDirentInfo, SmbDirentType, SmbOptions};
 use std::path::PathBuf;
 
 #[derive(FromArgs)]
@@ -53,19 +51,17 @@ fn read_secret_from_tty(prompt: &str) -> std::io::Result<String> {
     }
 }
 
-
 fn treeplus(client: &SmbClient, uri: &str, depth: usize) {
     let vec = client.list_dirplus(uri).unwrap();
     for entityplus in vec.into_iter() {
         let entityplus_uri = entityplus_uri(&entityplus, uri);
-        print_entry_plus(&entityplus,depth);
+        print_entry_plus(&entityplus, depth);
         // if is dir, iter directory
         if entityplus.get_type() == SmbDirentType::Dir {
             treeplus(client, &entityplus_uri.as_str(), depth + 1)
         }
     }
 }
-
 
 fn entityplus_uri(entity: &SmbDirentInfo, path: &str) -> String {
     let mut p = PathBuf::from(path);

--- a/examples/treeplus.rs
+++ b/examples/treeplus.rs
@@ -1,7 +1,7 @@
-use argh::FromArgs;
-
-use pavao::{SmbClient, SmbCredentials, SmbDirentInfo, SmbDirentType, SmbOptions};
 use std::path::PathBuf;
+
+use argh::FromArgs;
+use pavao::{SmbClient, SmbCredentials, SmbDirentInfo, SmbDirentType, SmbOptions};
 
 #[derive(FromArgs)]
 #[argh(description = "

--- a/examples/treeplus.rs
+++ b/examples/treeplus.rs
@@ -1,0 +1,89 @@
+use argh::FromArgs;
+use env_logger;
+use pavao::{
+    SmbClient, SmbCredentials, SmbDirent, SmbDirentInfo, SmbDirentType, SmbOptions, SmbStat,
+};
+use std::path::PathBuf;
+
+#[derive(FromArgs)]
+#[argh(description = "
+where positional can be: [smb://address[:port]]
+
+Please, report issues to <https://github.com/veeso/pavao>
+Please, consider supporting the author <https://ko-fi.com/veeso>")]
+struct Args {
+    #[argh(option, short = 'P', description = "specify password")]
+    password: Option<String>,
+    #[argh(option, short = 'u', description = "specify username")]
+    username: String,
+    #[argh(option, short = 'w', description = "specify workgroup")]
+    workgroup: String,
+    #[argh(option, short = 's', description = "specify share")]
+    share: String,
+    #[argh(positional, description = "smb://address[:port]")]
+    server: String,
+}
+
+fn main() {
+    assert!(env_logger::builder().try_init().is_ok());
+    let args: Args = argh::from_env();
+    let password = match args.password {
+        Some(p) => p,
+        None => read_secret_from_tty("Password: ").ok().unwrap(),
+    };
+    //setup server
+    let client = SmbClient::new(
+        SmbCredentials::default()
+            .server(args.server)
+            .share(args.share)
+            .password(password)
+            .username(args.username)
+            .workgroup(args.workgroup),
+        SmbOptions::default().one_share_per_server(true),
+    )
+    .unwrap();
+    treeplus(&client, "/DCIM", 0);
+}
+
+/// Read a secret from tty with customisable prompt
+fn read_secret_from_tty(prompt: &str) -> std::io::Result<String> {
+    match rpassword::read_password_from_tty(Some(prompt)) {
+        Ok(p) => Ok(p),
+        Err(err) => Err(err),
+    }
+}
+
+
+fn treeplus(client: &SmbClient, uri: &str, depth: usize) {
+    let vec = client.list_dirplus(uri).unwrap();
+    for entityplus in vec.into_iter() {
+        let entityplus_uri = entityplus_uri(&entityplus, uri);
+        print_entry_plus(&entityplus,depth);
+        // if is dir, iter directory
+        if entityplus.get_type() == SmbDirentType::Dir {
+            treeplus(client, &entityplus_uri.as_str(), depth + 1)
+        }
+    }
+}
+
+
+fn entityplus_uri(entity: &SmbDirentInfo, path: &str) -> String {
+    let mut p = PathBuf::from(path);
+    p.push(PathBuf::from(entity.name()));
+    p.as_path().to_string_lossy().to_string()
+}
+
+fn print_entry_plus(entityplus: &SmbDirentInfo, depth: usize) {
+    println!(
+        "{}{:32}\t{}\t{:x}\t{:?}",
+        fmt_depth(depth),
+        entityplus.name(),
+        entityplus.size,
+        entityplus.attrs,
+        entityplus.get_type(),
+    )
+}
+
+fn fmt_depth(depth: usize) -> String {
+    " ".repeat(depth * 4)
+}

--- a/examples/treeplus.rs
+++ b/examples/treeplus.rs
@@ -1,5 +1,5 @@
 use argh::FromArgs;
-use env_logger;
+
 use pavao::{SmbClient, SmbCredentials, SmbDirentInfo, SmbDirentType, SmbOptions};
 use std::path::PathBuf;
 
@@ -45,10 +45,7 @@ fn main() {
 
 /// Read a secret from tty with customisable prompt
 fn read_secret_from_tty(prompt: &str) -> std::io::Result<String> {
-    match rpassword::read_password_from_tty(Some(prompt)) {
-        Ok(p) => Ok(p),
-        Err(err) => Err(err),
-    }
+    rpassword::read_password_from_tty(Some(prompt))
 }
 
 fn treeplus(client: &SmbClient, uri: &str, depth: usize) {
@@ -58,7 +55,7 @@ fn treeplus(client: &SmbClient, uri: &str, depth: usize) {
         print_entry_plus(&entityplus, depth);
         // if is dir, iter directory
         if entityplus.get_type() == SmbDirentType::Dir {
-            treeplus(client, &entityplus_uri.as_str(), depth + 1)
+            treeplus(client, entityplus_uri.as_str(), depth + 1)
         }
     }
 }

--- a/examples/treeplus.rs
+++ b/examples/treeplus.rs
@@ -45,7 +45,7 @@ fn main() {
 
 /// Read a secret from tty with customisable prompt
 fn read_secret_from_tty(prompt: &str) -> std::io::Result<String> {
-    rpassword::read_password_from_tty(Some(prompt))
+    rpassword::prompt_password(prompt)
 }
 
 fn treeplus(client: &SmbClient, uri: &str, depth: usize) {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@
 
 use std::ffi::NulError;
 use std::io::Error as IoError;
+
 use thiserror::Error;
 
 /// Result returned by the Smb client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,8 +57,8 @@ pub(crate) mod utils;
 // -- exports
 pub use error::{SmbError, SmbResult};
 pub use smb::{
-    SmbClient, SmbCredentials, SmbDirent, SmbDirentType, SmbEncryptionLevel, SmbFile, SmbMode,
-    SmbModeClass, SmbOpenOptions, SmbOptions, SmbShareMode, SmbStat,
+    SmbClient, SmbCredentials, SmbDirent, SmbDirentInfo, SmbDirentType, SmbEncryptionLevel,
+    SmbFile, SmbMode, SmbModeClass, SmbOpenOptions, SmbOptions, SmbShareMode, SmbStat,
 };
 
 // -- mock

--- a/src/libsmbclient.rs
+++ b/src/libsmbclient.rs
@@ -3,7 +3,8 @@
 use std::{clone, default, mem, option};
 
 use libc::{
-    c_char, c_int, c_uint, c_ushort, c_void, mode_t, off_t, size_t, ssize_t, stat, time_t, timeval,
+    c_char, c_int, c_uint, c_ulong, c_ushort, c_void, mode_t, off_t, size_t, ssize_t, stat, time_t,
+    timespec, timeval,
 };
 
 #[repr(C)]
@@ -47,6 +48,53 @@ impl clone::Clone for smbc_dirent {
 }
 
 impl default::Default for smbc_dirent {
+    fn default() -> Self {
+        unsafe { mem::zeroed() }
+    }
+}
+#[repr(C)]
+#[derive(Copy)]
+/// Structure that represents all attributes of a directory entry.
+/// libsmb_file_info as implemented in libsmbclient.h
+pub struct libsmb_file_info {
+    /// Size of file
+    pub size: c_ulong,
+    /// DOS attributes of file
+    pub attrs: c_ushort,
+    /// User ID of file
+    pub uid: c_uint,
+    /// Group ID of file
+    pub gid: c_uint,
+    /// Birth/Create time of file (if supported by system)
+    ///Otherwise the value will be 0
+    pub btime_ts: timespec,
+    /// Modified time for the file
+    pub mtime_ts: timespec,
+    /// Access time for the file
+    pub atime_ts: timespec,
+    /// Change time for the file
+    pub ctime_ts: timespec,
+    /// Name of file
+    pub name: *mut c_char,
+    /// Short name of file
+    pub short_name: *mut c_char,
+}
+
+// impl std::fmt::Debug for timespec {
+//     fn fmt(&self, f:&mut Formatter<'_>) -> std::fmt::Result {
+//         f.debug_struct("timespec")
+//             .field("tv_sec", &self.tv_sec)
+//             .field("tv_nsec", &self.tv_nsec)
+//             .finish()
+//     }
+// }
+impl clone::Clone for libsmb_file_info {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl default::Default for libsmb_file_info {
     fn default() -> Self {
         unsafe { mem::zeroed() }
     }
@@ -213,6 +261,8 @@ pub type smbc_closedir_fn =
     option::Option<extern "C" fn(c: *mut SMBCCTX, dir: *mut SMBCFILE) -> c_int>;
 pub type smbc_readdir_fn =
     option::Option<extern "C" fn(c: *mut SMBCCTX, dir: *mut SMBCFILE) -> *mut smbc_dirent>;
+pub type smbc_readdirplus_fn =
+    option::Option<extern "C" fn(c: *mut SMBCCTX, dir: *mut SMBCFILE) -> *mut libsmb_file_info>;
 pub type smbc_getdents_fn = option::Option<
     extern "C" fn(
         c: *mut SMBCCTX,
@@ -419,6 +469,7 @@ extern "C" {
     pub fn smbc_getFunctionOpendir(c: *mut SMBCCTX) -> smbc_opendir_fn;
     pub fn smbc_getFunctionClosedir(c: *mut SMBCCTX) -> smbc_closedir_fn;
     pub fn smbc_getFunctionReaddir(c: *mut SMBCCTX) -> smbc_readdir_fn;
+    pub fn smbc_getFunctionReaddirPlus(c: *mut SMBCCTX) -> smbc_readdirplus_fn;
     pub fn smbc_getFunctionMkdir(c: *mut SMBCCTX) -> smbc_mkdir_fn;
     pub fn smbc_getFunctionRmdir(c: *mut SMBCCTX) -> smbc_rmdir_fn;
     pub fn smbc_getFunctionChmod(c: *mut SMBCCTX) -> smbc_chmod_fn;

--- a/src/libsmbclient.rs
+++ b/src/libsmbclient.rs
@@ -80,14 +80,6 @@ pub struct libsmb_file_info {
     pub short_name: *mut c_char,
 }
 
-// impl std::fmt::Debug for timespec {
-//     fn fmt(&self, f:&mut Formatter<'_>) -> std::fmt::Result {
-//         f.debug_struct("timespec")
-//             .field("tv_sec", &self.tv_sec)
-//             .field("tv_nsec", &self.tv_nsec)
-//             .finish()
-//     }
-// }
 impl clone::Clone for libsmb_file_info {
     fn clone(&self) -> Self {
         *self

--- a/src/smb/client.rs
+++ b/src/smb/client.rs
@@ -2,19 +2,18 @@
 //!
 //! module which exposes the Smb Client
 
+use std::sync::Mutex;
+use std::time::Duration;
+use std::{mem, ptr};
+
+use libc::{self, c_char, c_int};
+
 use super::{
     AuthService, SmbCredentials, SmbDirentInfo, SmbFile, SmbMode, SmbOpenOptions, SmbOptions,
     SmbStat,
 };
-use crate::{utils, SmbDirent};
-use crate::{SmbError, SmbResult};
-
 use crate::libsmbclient::{SMBCCTX as SmbContext, *};
-use libc::{self, c_char, c_int};
-use std::mem;
-use std::ptr;
-use std::sync::Mutex;
-use std::time::Duration;
+use crate::{utils, SmbDirent, SmbError, SmbResult};
 
 lazy_static! {
     static ref AUTH_SERVICE: Mutex<AuthService> = Mutex::new(AuthService::default());
@@ -351,9 +350,7 @@ impl SmbClient {
         &self,
         get_func: unsafe extern "C" fn(*mut SMBCCTX) -> Option<T>,
     ) -> std::io::Result<T> {
-        unsafe {
-            get_func(self.ctx).ok_or_else(|| std::io::Error::from_raw_os_error(libc::EINVAL))
-        }
+        unsafe { get_func(self.ctx).ok_or_else(|| std::io::Error::from_raw_os_error(libc::EINVAL)) }
     }
 
     /// Setup options in the context
@@ -452,14 +449,15 @@ impl Drop for SmbClient {
 #[cfg(test)]
 #[cfg(feature = "with-containers")]
 mod test {
-    use super::*;
-    use crate::{mock, SmbDirentType};
-
-    use pretty_assertions::{assert_eq, assert_ne};
-    use serial_test::serial;
     use std::io::{Cursor, Read};
     use std::path::Path;
     use std::time::UNIX_EPOCH;
+
+    use pretty_assertions::{assert_eq, assert_ne};
+    use serial_test::serial;
+
+    use super::*;
+    use crate::{mock, SmbDirentType};
 
     #[test]
     #[serial]

--- a/src/smb/client.rs
+++ b/src/smb/client.rs
@@ -352,7 +352,7 @@ impl SmbClient {
         get_func: unsafe extern "C" fn(*mut SMBCCTX) -> Option<T>,
     ) -> std::io::Result<T> {
         unsafe {
-            get_func(self.ctx).ok_or_else(|| std::io::Error::from_raw_os_error(libc::EINVAL as i32))
+            get_func(self.ctx).ok_or_else(|| std::io::Error::from_raw_os_error(libc::EINVAL))
         }
     }
 

--- a/src/smb/client.rs
+++ b/src/smb/client.rs
@@ -466,10 +466,7 @@ mod test {
     fn should_initialize_client() {
         mock::logger();
         let client = init_client();
-        assert_eq!(
-            client.uri.as_str(),
-            "smb://192.168.1.216:4445/main storage/temp"
-        );
+        assert_eq!(client.uri.as_str(), "smb://localhost:3445/temp");
         assert_eq!(client.ctx.is_null(), false);
         finalize_client(client);
     }
@@ -623,11 +620,11 @@ mod test {
         assert_eq!(abc.name(), "ghi");
         assert_eq!(abc.get_type(), SmbDirentType::File);
         let def = entries.get(1).unwrap();
-        assert_eq!(def.name(), "jkl");
-        assert_eq!(def.get_type(), SmbDirentType::File);
+        assert_eq!(def.name(), "hil");
+        assert_eq!(def.get_type(), SmbDirentType::Dir);
         let jfk = entries.get(2).unwrap();
-        assert_eq!(jfk.name(), "hil");
-        assert_eq!(jfk.get_type(), SmbDirentType::Dir);
+        assert_eq!(jfk.name(), "jkl");
+        assert_eq!(jfk.get_type(), SmbDirentType::File);
         finalize_client(client);
     }
 

--- a/src/smb/mod.rs
+++ b/src/smb/mod.rs
@@ -6,8 +6,7 @@ mod auth_service;
 mod client;
 mod types;
 
-pub use client::SmbClient;
-pub use types::*;
-
 // -- priv
 use auth_service::AuthService;
+pub use client::SmbClient;
+pub use types::*;

--- a/src/smb/types/credentials.rs
+++ b/src/smb/types/credentials.rs
@@ -47,9 +47,9 @@ impl SmbCredentials {
 #[cfg(test)]
 mod test {
 
-    use super::*;
-
     use pretty_assertions::assert_eq;
+
+    use super::*;
 
     #[test]
     fn should_init_smb_credentials() {

--- a/src/smb/types/dirent.rs
+++ b/src/smb/types/dirent.rs
@@ -2,11 +2,11 @@
 //!
 //! module which exposes the smb dir entry
 
-use crate::utils::char_ptr_to_string;
-use crate::SmbError;
+use libc::c_uint;
 
 use crate::libsmbclient::smbc_dirent;
-use libc::c_uint;
+use crate::utils::char_ptr_to_string;
+use crate::SmbError;
 
 /// Smb directory entity
 #[derive(Debug, Clone)]
@@ -100,10 +100,10 @@ impl TryFrom<c_uint> for SmbDirentType {
 #[cfg(test)]
 mod test {
 
+    use pretty_assertions::assert_eq;
+
     use super::*;
     use crate::utils;
-
-    use pretty_assertions::assert_eq;
 
     #[test]
     fn should_convert_dirent_type_to_uint() {

--- a/src/smb/types/file.rs
+++ b/src/smb/types/file.rs
@@ -2,15 +2,15 @@
 //!
 //! file type returned by open functions on server
 
-use crate::utils;
-use crate::SmbClient;
+use std::io::{self, Read, Seek, SeekFrom, Write};
+
+use libc::{c_int, c_void, mode_t, off_t};
 
 use crate::libsmbclient::{
     smbc_getFunctionClose, smbc_getFunctionLseek, smbc_getFunctionRead, smbc_getFunctionWrite,
     SMBCFILE,
 };
-use libc::{c_int, c_void, mode_t, off_t};
-use std::io::{self, Read, Seek, SeekFrom, Write};
+use crate::{utils, SmbClient};
 
 pub struct SmbFile<'a> {
     smbc: &'a SmbClient,
@@ -174,9 +174,9 @@ impl SmbOpenOptions {
 #[cfg(test)]
 mod test {
 
-    use super::*;
-
     use pretty_assertions::assert_eq;
+
+    use super::*;
 
     #[test]
     fn should_initialize_open_options() {

--- a/src/smb/types/mod.rs
+++ b/src/smb/types/mod.rs
@@ -14,4 +14,4 @@ pub use dirent::{SmbDirent, SmbDirentType};
 pub use file::{SmbFile, SmbOpenOptions};
 pub use mode::{SmbMode, SmbModeClass};
 pub use options::{SmbEncryptionLevel, SmbOptions, SmbShareMode};
-pub use stat::SmbStat;
+pub use stat::{SmbDirentInfo, SmbStat};

--- a/src/smb/types/mode.rs
+++ b/src/smb/types/mode.rs
@@ -168,9 +168,9 @@ impl From<SmbModeClass> for mode_t {
 #[cfg(test)]
 mod test {
 
-    use super::*;
-
     use pretty_assertions::assert_eq;
+
+    use super::*;
 
     #[test]
     fn should_create_unix_pex_class() {

--- a/src/smb/types/options.rs
+++ b/src/smb/types/options.rs
@@ -140,9 +140,9 @@ impl From<SmbEncryptionLevel> for smbc_smb_encrypt_level {
 #[cfg(test)]
 mod test {
 
-    use super::*;
-
     use pretty_assertions::assert_eq;
+
+    use super::*;
 
     #[test]
     fn should_initialize_smb_options() {

--- a/src/smb/types/stat.rs
+++ b/src/smb/types/stat.rs
@@ -47,13 +47,22 @@ impl From<stat> for SmbStat {
         Self {
             accessed: time_t_to_system_time(s.st_atime),
             blocks: s.st_blocks,
+            #[cfg(target_os = "macos")]
+            blksize: s.st_blksize as i64,
+            #[cfg(not(target_os = "macos"))]
             blksize: s.st_blksize,
             created: time_t_to_system_time(s.st_ctime),
             dev: s.st_dev as i32,
             gid: s.st_gid,
             mode: SmbMode::from(s.st_mode),
             modified: time_t_to_system_time(s.st_mtime),
+            #[cfg(target_os = "macos")]
+            nlink: s.st_nlink as u64,
+            #[cfg(not(target_os = "macos"))]
             nlink: s.st_nlink,
+            #[cfg(target_os = "macos")]
+            rdev: s.st_rdev as u64,
+            #[cfg(not(target_os = "macos"))]
             rdev: s.st_rdev,
             size: s.st_size as u64,
             uid: s.st_uid,

--- a/src/smb/types/stat.rs
+++ b/src/smb/types/stat.rs
@@ -45,17 +45,17 @@ impl From<stat> for SmbStat {
     fn from(s: stat) -> Self {
         Self {
             accessed: time_t_to_system_time(s.st_atime),
-            blocks: s.st_blocks as i64,
-            blksize: s.st_blksize as i64,
+            blocks: s.st_blocks,
+            blksize: s.st_blksize,
             created: time_t_to_system_time(s.st_ctime),
             dev: s.st_dev as i32,
-            gid: s.st_gid as u32,
+            gid: s.st_gid,
             mode: SmbMode::from(s.st_mode),
             modified: time_t_to_system_time(s.st_mtime),
-            nlink: s.st_nlink as u64,
-            rdev: s.st_rdev as u64,
+            nlink: s.st_nlink,
+            rdev: s.st_rdev,
             size: s.st_size as u64,
-            uid: s.st_uid as u32,
+            uid: s.st_uid,
         }
     }
 }
@@ -116,14 +116,14 @@ impl TryFrom<libsmb_file_info> for SmbDirentInfo {
         Ok(Self {
             name,
             short_name,
-            size: di.size as u64,
+            size: di.size,
             ctime: time_t_to_system_time(di.ctime_ts.tv_sec),
             btime: time_t_to_system_time(di.btime_ts.tv_sec),
             mtime: time_t_to_system_time(di.mtime_ts.tv_sec),
             atime: time_t_to_system_time(di.atime_ts.tv_sec),
-            uid: di.uid as u32,
-            gid: di.gid as u32,
-            attrs: di.attrs as u16,
+            uid: di.uid,
+            gid: di.gid,
+            attrs: di.attrs,
         })
     }
 }

--- a/src/smb/types/stat.rs
+++ b/src/smb/types/stat.rs
@@ -52,6 +52,9 @@ impl From<stat> for SmbStat {
             #[cfg(not(target_os = "macos"))]
             blksize: s.st_blksize,
             created: time_t_to_system_time(s.st_ctime),
+            #[cfg(target_os = "macos")]
+            dev: s.st_dev,
+            #[cfg(not(target_os = "macos"))]
             dev: s.st_dev as i32,
             gid: s.st_gid,
             mode: SmbMode::from(s.st_mode),

--- a/src/smb/types/stat.rs
+++ b/src/smb/types/stat.rs
@@ -2,13 +2,14 @@
 //!
 //! file stat type
 
-use crate::{libsmbclient::libsmb_file_info, utils::char_ptr_to_string};
-use crate::{SmbDirentType, SmbError};
-
-use super::SmbMode;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use libc::{stat, time_t};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use super::SmbMode;
+use crate::libsmbclient::libsmb_file_info;
+use crate::utils::char_ptr_to_string;
+use crate::{SmbDirentType, SmbError};
 
 /// DOS Attribute mask for DIRECTORY
 const FILE_ATTRIBUTE_DIRECTORY: u16 = 0x0010;
@@ -137,9 +138,9 @@ fn time_t_to_system_time(t: time_t) -> SystemTime {
 #[cfg(test)]
 mod test {
 
-    use super::*;
-
     use pretty_assertions::assert_ne;
+
+    use super::*;
 
     #[test]
     fn should_convert_time_t_into_system_time() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,16 +2,15 @@
 //!
 //! utilities module
 
-use crate::SmbError;
-
-use super::SmbResult;
-
-use libc::{c_char, c_int};
-
 use std::borrow::Cow;
 use std::ffi::{CStr, CString};
 use std::io::{self, Write};
 use std::slice;
+
+use libc::{c_char, c_int};
+
+use super::SmbResult;
+use crate::SmbError;
 
 #[inline(always)]
 /// Ok(ptr) for non-null ptr or Err(last_os_error) otherwise
@@ -111,9 +110,9 @@ pub fn char_ptr_to_string(ptr: *const c_char) -> SmbResult<String> {
 #[cfg(test)]
 mod test {
 
-    use super::*;
-
     use pretty_assertions::assert_eq;
+
+    use super::*;
 
     #[test]
     fn should_convert_str_to_cstring() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -77,7 +77,7 @@ pub fn to_result_with_le<T: Eq + From<i8>>(t: T) -> io::Result<T> {
 #[inline(always)]
 /// to io::Result with Err(from_raw_os_error(errno)) if t == -1
 pub fn to_result_with_errno<T: Eq + From<i8>>(t: T, errno: c_int) -> io::Result<T> {
-    to_result_with_error(t, io::Error::from_raw_os_error(errno as i32))
+    to_result_with_error(t, io::Error::from_raw_os_error(errno))
 }
 
 #[inline(always)]


### PR DESCRIPTION
# 3- Function to get a list of files along with metadata

Feature #3 

Added list_dirplus function along with an example. 

## Description

The previous list_dir function required users to fetch a list of files and request metadata for each file individually, which was inefficient and could lead to unnecessary network traffic. To improve performance, I added a new list_dirplus function that uses the getFunctionReaddirplus function in libsmbclient to retrieve a list of files along with their metadata in a single request. This significantly reduced the number of network requests required and improved overall performance.

List here your changes

- I added the type and function associated with it along with example code and test.
- Added list_dirplus function along with an example. 


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
      The warning to remove cast has been added but it was already present in the code before. 
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, Linux compatible (Checked for Windows,Linux and Android FTP server)

