### PR TITLE
feat: Add support for Linux RISC-V64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,12 +4,14 @@ fn main() {
     cfg_aliases! {
         // Platforms
         aarch64: { target_arch = "aarch64" },
+        riscv64: { target_arch = "riscv64" },
         x86_64: { target_arch = "x86_64" },
         macos: { target_os = "macos" },
         linux: { target_os = "linux" },
         unix: { target_family = "unix" },
         // exclusive features
         linux_aarch64: { all(linux, aarch64) },
+        linux_riscv64: { all(linux, riscv64) },
         linux_x86_64: { all(linux, x86_64) }
     }
 

--- a/src/smb/types/stat.rs
+++ b/src/smb/types/stat.rs
@@ -53,12 +53,16 @@ impl From<stat> for SmbStat {
             blksize: s.st_blksize,
             #[cfg(linux_aarch64)]
             blksize: s.st_blksize as i64,
+            #[cfg(linux_riscv64)]
+            blksize: s.st_blksize as i64,
             created: time_t_to_system_time(s.st_ctime),
             #[cfg(target_os = "macos")]
             dev: s.st_dev,
             #[cfg(linux_x86_64)]
             dev: s.st_dev as i32,
             #[cfg(linux_aarch64)]
+            dev: s.st_dev as i32,
+            #[cfg(linux_riscv64)]
             dev: s.st_dev as i32,
             gid: s.st_gid,
             mode: SmbMode::from(s.st_mode),
@@ -69,11 +73,15 @@ impl From<stat> for SmbStat {
             nlink: s.st_nlink,
             #[cfg(linux_aarch64)]
             nlink: s.st_nlink as u64,
+            #[cfg(linux_riscv64)]
+            nlink: s.st_nlink as u64,
             #[cfg(target_os = "macos")]
             rdev: s.st_rdev as u64,
             #[cfg(linux_x86_64)]
             rdev: s.st_rdev,
             #[cfg(linux_aarch64)]
+            rdev: s.st_rdev as u64,
+            #[cfg(linux_riscv64)]
             rdev: s.st_rdev as u64,
             size: s.st_size as u64,
             uid: s.st_uid,


### PR DESCRIPTION
# ISSUE 7 - feat: Add support for Linux RISC-V64

Fixes #7

## Description

Add support for Linux RISC-V64
- Use `libc::stat` of Linux RISC-V64.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
