### PR TITLE
Add support for ARM 32 bit

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,7 @@ use cfg_aliases::cfg_aliases;
 fn main() {
     cfg_aliases! {
         // Platforms
+        arm: { target_arch = "arm" },
         aarch64: { target_arch = "aarch64" },
         riscv64: { target_arch = "riscv64" },
         x86_64: { target_arch = "x86_64" },
@@ -12,7 +13,8 @@ fn main() {
         // exclusive features
         linux_aarch64: { all(linux, aarch64) },
         linux_riscv64: { all(linux, riscv64) },
-        linux_x86_64: { all(linux, x86_64) }
+        linux_x86_64: { all(linux, x86_64) },
+        linux_arm: { all(linux, arm) },
     }
 
     match pkg_config::find_library("smbclient") {

--- a/src/smb/types/stat.rs
+++ b/src/smb/types/stat.rs
@@ -44,47 +44,59 @@ pub struct SmbStatVfs {
 impl From<statvfs> for SmbStatVfs {
     fn from(s: statvfs) -> Self {
         Self {
-            bsize: s.f_bsize,
-            frsize: s.f_frsize,
+            bsize: s.f_bsize as u64,
+            frsize: s.f_frsize as u64,
             #[cfg(target_os = "macos")]
             blocks: s.f_blocks as u64,
             #[cfg(linux_x86_64)]
             blocks: s.f_blocks,
             #[cfg(linux_aarch64)]
             blocks: s.f_blocks,
+            #[cfg(linux_arm)]
+            blocks: s.f_blocks as u64,
             #[cfg(target_os = "macos")]
             bfree: s.f_bfree as u64,
             #[cfg(linux_x86_64)]
             bfree: s.f_bfree,
             #[cfg(linux_aarch64)]
             bfree: s.f_bfree,
+            #[cfg(linux_arm)]
+            bfree: s.f_bfree as u64,
             #[cfg(target_os = "macos")]
             bavail: s.f_bavail as u64,
             #[cfg(linux_x86_64)]
             bavail: s.f_bavail,
             #[cfg(linux_aarch64)]
             bavail: s.f_bavail,
+            #[cfg(linux_arm)]
+            bavail: s.f_bavail as u64,
             #[cfg(target_os = "macos")]
             files: s.f_files as u64,
             #[cfg(linux_x86_64)]
             files: s.f_files,
             #[cfg(linux_aarch64)]
             files: s.f_files,
+            #[cfg(linux_arm)]
+            files: s.f_files as u64,
             #[cfg(target_os = "macos")]
             ffree: s.f_ffree as u64,
             #[cfg(linux_x86_64)]
             ffree: s.f_ffree,
             #[cfg(linux_aarch64)]
             ffree: s.f_ffree,
+            #[cfg(linux_arm)]
+            ffree: s.f_ffree as u64,
             #[cfg(target_os = "macos")]
             favail: s.f_favail as u64,
             #[cfg(linux_x86_64)]
             favail: s.f_favail,
             #[cfg(linux_aarch64)]
             favail: s.f_favail,
-            fsid: s.f_fsid,
-            flag: s.f_flag,
-            namemax: s.f_namemax,
+            #[cfg(linux_arm)]
+            favail: s.f_favail as u64,
+            fsid: s.f_fsid as u64,
+            flag: s.f_flag as u64,
+            namemax: s.f_namemax as u64,
         }
     }
 }
@@ -121,12 +133,14 @@ impl From<stat> for SmbStat {
     fn from(s: stat) -> Self {
         Self {
             accessed: time_t_to_system_time(s.st_atime),
-            blocks: s.st_blocks,
+            blocks: s.st_blocks as i64,
             #[cfg(target_os = "macos")]
             blksize: s.st_blksize as i64,
             #[cfg(linux_x86_64)]
             blksize: s.st_blksize,
             #[cfg(linux_aarch64)]
+            blksize: s.st_blksize as i64,
+            #[cfg(linux_arm)]
             blksize: s.st_blksize as i64,
             #[cfg(linux_riscv64)]
             blksize: s.st_blksize as i64,
@@ -136,6 +150,8 @@ impl From<stat> for SmbStat {
             #[cfg(linux_x86_64)]
             dev: s.st_dev as i32,
             #[cfg(linux_aarch64)]
+            dev: s.st_dev as i32,
+            #[cfg(linux_arm)]
             dev: s.st_dev as i32,
             #[cfg(linux_riscv64)]
             dev: s.st_dev as i32,
@@ -148,6 +164,8 @@ impl From<stat> for SmbStat {
             nlink: s.st_nlink,
             #[cfg(linux_aarch64)]
             nlink: s.st_nlink as u64,
+            #[cfg(linux_arm)]
+            nlink: s.st_nlink as u64,
             #[cfg(linux_riscv64)]
             nlink: s.st_nlink as u64,
             #[cfg(target_os = "macos")]
@@ -155,6 +173,8 @@ impl From<stat> for SmbStat {
             #[cfg(linux_x86_64)]
             rdev: s.st_rdev,
             #[cfg(linux_aarch64)]
+            rdev: s.st_rdev as u64,
+            #[cfg(linux_arm)]
             rdev: s.st_rdev as u64,
             #[cfg(linux_riscv64)]
             rdev: s.st_rdev as u64,
@@ -220,7 +240,7 @@ impl TryFrom<libsmb_file_info> for SmbDirentInfo {
         Ok(Self {
             name,
             short_name,
-            size: di.size,
+            size: di.size as u64,
             ctime: time_t_to_system_time(di.ctime_ts.tv_sec),
             btime: time_t_to_system_time(di.btime_ts.tv_sec),
             mtime: time_t_to_system_time(di.mtime_ts.tv_sec),

--- a/src/smb/types/stat.rs
+++ b/src/smb/types/stat.rs
@@ -1,6 +1,7 @@
 //! # Stat
 //!
 //! file stat type
+#![allow(clippy::unnecessary_cast)]
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 


### PR DESCRIPTION
Fixes https://github.com/veeso/pavao/issues/14

## Description

This adds support for cross-compiling(or also compiling) app on armv7 - 32 bit.

I tried to find a way to make cross-compiling easier, but not found anything(I wanted to remove libsamba from build dependencies, but looks that for dynamic libraries, also this libraries needs to be available during build)
 
Tested via cross tool
```
cargo install cross
```
added Cross.toml file
```
[build]
pre-build = [
    "dpkg --add-architecture $CROSS_DEB_ARCH",
    "apt-get update && apt-get install -y libsmbclient-dev:$CROSS_DEB_ARCH",
```
and then executed
```
cross build  --target armv7-unknown-linux-gnueabihf -v --example tree --release
``` 


## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [ ] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit
