### PR TITLE
chore(build): improve macOS linking for libsmbclient 

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,24 +8,31 @@ fn main() {
         riscv64: { target_arch = "riscv64" },
         x86_64: { target_arch = "x86_64" },
         linux: { target_os = "linux" },
+        macos: { target_os = "macos" },
         // exclusive features
-        linux_aarch64: { all(linux, aarch64) },
-        linux_riscv64: { all(linux, riscv64) },
-        linux_x86_64: { all(linux, x86_64) },
-        linux_arm: { all(linux, arm) },
+        linux_aarch64: { all(linux, aarch64, unix) },
+        linux_riscv64: { all(linux, riscv64, unix) },
+        linux_x86_64: { all(linux, x86_64, unix) },
+        linux_arm: { all(linux, arm, unix) },
     }
 
     match pkg_config::find_library("smbclient") {
         Ok(_) => {
             if cfg!(target_os = "macos") {
-                println!("cargo:rustc-flags=-L /usr/local/lib -l smbclient");
+                if cfg!(target_arch = "aarch64") {
+                    println!("cargo:rustc-link-search=/opt/homebrew/opt/samba/lib");
+                } else if cfg!(target_arch = "x86_64") {
+                    println!("cargo:rustc-link-search=/usr/local/Homebrew/opt/samba/lib");
+                }
+                println!("cargo:rustc-link-lib=smbclient");
             } else {
-                println!("cargo:rustc-flags=-l smbclient");
+                println!("cargo:rustc-link-lib=smbclient");
             }
         }
         Err(e) => {
             println!(
-                "error: SMB Client library not found! Probably libsmbclient is not installed."
+                "error: SMB Client library not found! Make sure libsmbclient is installed. \
+                For macOS, install it via Homebrew with `brew install samba`."
             );
             panic!("{}", e);
         }


### PR DESCRIPTION
Fixes #9

## Description

- improve macOS linking for libsmbclient 

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I formatted the code with `cargo fmt`
- [ ] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have introduced no new *C-bindings*
- [ ] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

---

```
$ cargo run --example tree -- -u username -w workspace -s share -P password smb://hostname
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/examples/tree -u username -w workspace -s share -P password 'smb://hostname'`
[2024-12-19T04:31:08Z ERROR pavao::smb::client] failed to open directory: returned a bad file descriptor
thread 'main' panicked at examples/tree.rs:53:40:
called `Result::unwrap()` on an `Err` value: BadFileDescriptor
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```