### PR TITLE
chore: replace deprecated `actions-rs/toolchain` with `actions-rust-lang/setup-rust-toolchain` and use checkoutv4 instead of v2

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,24 +10,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo apt update && sudo apt install -y libsmbclient-dev libsmbclient
-      - uses: actions-rs/toolchain@v1
+      - name: Setup Rust toolchain and cache
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
       - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all-targets
+        run: cargo build --all-targets
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --no-fail-fast
+        run: cargo test --no-default-features --no-fail-fast
         env:
           RUST_LOG: trace
       - name: Format

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,13 +10,12 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: brew update && brew install samba pkg-config && brew link --force samba
-      - uses: actions-rs/toolchain@v1
+      - name: Setup Rust toolchain and cache
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
-          override: true
           components: rustfmt, clippy
       - name: Build
         run: cargo build --all-targets


### PR DESCRIPTION
- checkout v2 -> v4
- `actions-rs/toolchain` -> `actions-rust-lang/setup-rust-toolchain`

this would allow to use newer nodejs runtime for action runs.

cc @veeso  