### PR TITLE
feat: do matrix builds for macos runs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,12 @@ env:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest # aka macos-15, arm based runner
+          - macos-13 # intel based runner
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
followup #23 

do matrix builds to cover both intel and arm runs.