### PR TITLE
Race condition in SmbClient::new

### DIFF
--- a/src/smb/client.rs
+++ b/src/smb/client.rs
@@ -64,9 +64,9 @@ impl SmbClient {
         // insert credentials
         trace!("creating context...");
         // get current context
-        let is_ctx_null = SMBCTX.lock().map_err(|_| SmbError::Mutex)?.is_null();
+        let mut ctx_lock = SMBCTX.lock().map_err(|_| SmbError::Mutex)?;
         // if context is null, create a new one
-        if is_ctx_null {
+        if ctx_lock.is_null() {
             unsafe {
                 let ctx = utils::result_from_ptr_mut(smbc_new_context())?;
                 // set options
@@ -83,7 +83,7 @@ impl SmbClient {
                     .insert(Self::auth_service_uuid(smb_ctx), credentials);
 
                 // set context
-                SMBCTX.lock().map_err(|_| SmbError::Mutex)?.set(smb_ctx);
+                ctx_lock.set(smb_ctx);
             }
         }
         Ok(smbc)


### PR DESCRIPTION
# ISSUE 28 - Race condition in SmbClient::new

Fixes #28

## Description
- The lock protecting the context is held throughoutthe entire initialization 


## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the contribution guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I formatted the code with `cargo fmt`
- [ ] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have introduced no new *C-bindings*
- [ ] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit
