### PR TITLE
fix: Make SmbClient implement Debug

### DIFF
--- a/pavao/src/smb/client.rs
+++ b/pavao/src/smb/client.rs
@@ -52,6 +52,7 @@ lazy_static! {
 }
 
 /// Smb protocol client
+#[derive(Debug)]
 pub struct SmbClient {
     uri: String,
 }


### PR DESCRIPTION
## Description
Add automatic implementation of Debug for SmbClient.

Allows to add this struct to another struct that implements Debug.

## Type of change

Please select relevant options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [X] My code follows the contribution guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I formatted the code with `cargo fmt`
- [X] I checked my code using `cargo clippy` and reports no warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have introduced no new *C-bindings*
- [X] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [X] I increased or maintained the code coverage for the project, compared to the previous commit
